### PR TITLE
Extend share sheet action with titles and URLs

### DIFF
--- a/lib/component/story_information.dart
+++ b/lib/component/story_information.dart
@@ -161,7 +161,7 @@ class StoryInformation extends HookWidget {
                   icon: Icon(
                     Feather.share_2,
                   ),
-                  onPressed: () => handleShare(item.id),
+                  onPressed: () => handleShare(item.id, item.title, item.url),
                 ),
               ],
             ),

--- a/lib/component/story_information.dart
+++ b/lib/component/story_information.dart
@@ -161,7 +161,7 @@ class StoryInformation extends HookWidget {
                   icon: Icon(
                     Feather.share_2,
                   ),
-                  onPressed: () => handleShare(item.id, item.title, item.url),
+                  onPressed: () => handleShare(id: item.id, title: item.title, postUrl: item.url),
                 ),
               ],
             ),

--- a/lib/helpers.dart
+++ b/lib/helpers.dart
@@ -10,7 +10,7 @@ void handleShare({int id, String title, String postUrl}) {
   String text =
       "Read it on Hacker News: $hnUrl \r\r or go straight to the article: $postUrl";
 
-  Share.share(text, subject: $title);
+  Share.share(text, subject: title);
 }
 
 String buildHackerNewsURL(int id) {

--- a/lib/helpers.dart
+++ b/lib/helpers.dart
@@ -5,12 +5,25 @@ import 'package:stingray/history.dart';
 import 'package:stingray/model/item.dart';
 
 void handleShare(int id) {
-  String url = "https://news.ycombinator.com/item?id=$id";
+  String hnUrl = buildHackerNewsURL(id);
 
   String text =
-      "Hey, check out this Hacker News story that I read via Stingray!\r\r $url";
+      "Hey, check out this Hacker News story that I read via Stingray!\r\r $hnUrl";
 
   Share.share(text);
+}
+
+void handleShare(int id, String title, String postUrl) {
+  String hnUrl = buildHackerNewsURL(id);
+
+  String text =
+      "Read it on Hacker News: $hnUrl \r\r or go straight to the article: $postUrl";
+
+  Share.share(text, subject: $title);
+}
+
+String buildHackerNewsURL(int id) {
+  return "https://news.ycombinator.com/item?id=$id";
 }
 
 void handleUpvote(context, {Item item}) async {

--- a/lib/helpers.dart
+++ b/lib/helpers.dart
@@ -4,16 +4,7 @@ import 'package:stingray/auth.dart';
 import 'package:stingray/history.dart';
 import 'package:stingray/model/item.dart';
 
-void handleShare(int id) {
-  String hnUrl = buildHackerNewsURL(id);
-
-  String text =
-      "Hey, check out this Hacker News story that I read via Stingray!\r\r $hnUrl";
-
-  Share.share(text);
-}
-
-void handleShare(int id, String title, String postUrl) {
+void handleShare({int id, String title, String postUrl}) {
   String hnUrl = buildHackerNewsURL(id);
 
   String text =


### PR DESCRIPTION
Extends the share sheet functionality to include the title of the HN article in the subject of their share sheet, as well as both the Hacker News URL and the original post URL in the body text.

